### PR TITLE
Use hostname for rabbitmq_nodename env var

### DIFF
--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -1,7 +1,7 @@
 name: rabbitmq-ha
 apiVersion: v1
 appVersion: 3.7.0
-version: 0.1.1
+version: 0.1.2
 description: Highly available RabbitMQ cluster, the open source message broker
   software that implements the Advanced Message Queuing Protocol (AMQP).
 keywords:

--- a/stable/rabbitmq-ha/templates/statefulset.yaml
+++ b/stable/rabbitmq-ha/templates/statefulset.yaml
@@ -56,7 +56,7 @@ spec:
             - name: RABBITMQ_USE_LONGNAME
               value: "true"
             - name: RABBITMQ_NODENAME
-              value: "rabbit@$(MY_POD_IP)"
+              value: "rabbit@$(HOSTNAME)"
             - name: K8S_SERVICE_NAME
               value: {{ template "rabbitmq-ha.fullname" . }}
             - name: RABBITMQ_ERLANG_COOKIE


### PR DESCRIPTION
-Use Hostname instead of Pod IP to ensure persisted config directory name is stable (currently changes when Pod IP changes)